### PR TITLE
Remove _lpdf suffix from sampling statements in the Stan models

### DIFF
--- a/stan_models/psma_stan.stan
+++ b/stan_models/psma_stan.stan
@@ -197,9 +197,9 @@ model {
   weights ~ dirichlet(eta0);
   
   for(n in 1:N) {
-    theta[n] ~ normal_lpdf(theta0, tau);
-    // theta[n] ~ psma_normal_prior_mini_lpdf(theta0, tau, sqrt(vi[n]), alpha, eta);
-    yi[n] ~ psma_normal_mini_lpdf(theta[n], theta0, tau, sqrt(vi[n]), alpha, eta, 1, cutoff);
+    theta[n] ~ normal(theta0, tau);
+    // theta[n] ~ psma_normal_prior_mini(theta0, tau, sqrt(vi[n]), alpha, eta);
+    yi[n] ~ psma_normal_mini(theta[n], theta0, tau, sqrt(vi[n]), alpha, eta, 1, cutoff);
   }
   
 }

--- a/stan_models/psma_stan_gamma_prior.stan
+++ b/stan_models/psma_stan_gamma_prior.stan
@@ -198,9 +198,9 @@ model {
   // weights ~ dirichlet(eta0);
   
   for(n in 1:N) {
-    theta[n] ~ normal_lpdf(theta0, tau);
-    // theta[n] ~ psma_normal_prior_mini_lpdf(theta0, tau, sqrt(vi[n]), alpha, eta);
-    yi[n] ~ psma_normal_mini_lpdf(theta[n], theta0, tau, sqrt(vi[n]), alpha, eta, 1, cutoff);
+    theta[n] ~ normal(theta0, tau);
+    // theta[n] ~ psma_normal_prior_mini(theta0, tau, sqrt(vi[n]), alpha, eta);
+    yi[n] ~ psma_normal_mini(theta[n], theta0, tau, sqrt(vi[n]), alpha, eta, 1, cutoff);
   }
   
 }


### PR DESCRIPTION
Sampling statements don't need the `_lpdf` suffix in the distribution name.
```diff
-x ~ normal_lpdf(0, 1);
+x ~ normal(0, 1);
```
The suffix causes RStan to emit a warning stan-dev/stanc3#969